### PR TITLE
Remove flagging of potential artifacts and check for duplicate chr/pos

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -604,6 +604,10 @@ GetWTandMutCount <- function(loci_file, allele_frequencies_file) {
     return(NULL)
   }
   subs.data = subs.data[order(subs.data[,1], subs.data[,2]),]
+
+  if (nrow(subs.data)!=nrow(unique(subs.data[, 1:2]))) {
+	  stop("The input contains at least one pair of mutations at the same position. Chromosome and position must be unique for this pipeline to run.")
+  }
   
   # Replace dinucleotides and longer with just the first base. Here we assume the depth of the second base is the same and the number of dinucleotides is so low that removing the second base is negligable
   subs.data[,3] = apply(as.data.frame(subs.data[,3]), 1, function(x) { substring(x, 1,1) })


### PR DESCRIPTION
Two small fixes are enclosed:

The pipeline flags mutations that have a VAF that is not significantly different from the expected sequencing basepair error rate and sets their no.chrs.bearing.mut to 0. This is obviously unhelpful in the multi-sample scenario. The code for this check has been commented out and could be removed completely. 

The second commit checks for duplicates in chr/pos and stops the pipeline when this is encountered. The effect of duplicate chr/pos is that the duplicate is removed, which then causes a mismatch in data further down the pipeline, hence the stop inclusion when this occurs.